### PR TITLE
fix missing setuptools

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ name = "sip"
 description = "A Python bindings generator for C/C++ libraries"
 readme = "README.md"
 urls.homepage = "https://github.com/Python-SIP/sip"
-dependencies = ["packaging", "tomli; python_version<'3.11'"]
+dependencies = ["packaging", "setuptools", "tomli; python_version<'3.11'"]
 requires-python = ">=3.8"
 license = {file = "LICENSE"}
 classifiers = ["License :: OSI Approved :: BSD License"]


### PR DESCRIPTION
Not sure if it was intentional, but https://github.com/Python-SIP/sip/commit/f32039b07c47280039dcdcd0f8a2b1323fda912e dropped the dependency on `setuptools` even though setuptools_builder.py still needs it ofc
