### PR TITLE
Run the tests with the current Python version, not the default one

### DIFF
--- a/test/utils/sip_test_case.py
+++ b/test/utils/sip_test_case.py
@@ -47,7 +47,7 @@ class SIPTestCase(unittest.TestCase):
 
         # Build the extension module.
         cwd = os.getcwd()
-        subprocess.run(['sip-build', '--verbose'], cwd=test_dir).check_returncode()
+        subprocess.run([sys.executable, '-m', 'sipbuild.tools.build', '--verbose'], cwd=test_dir).check_returncode()
         os.chdir(cwd)
 
         # Move the extension module to the test directory.


### PR DESCRIPTION
This allows us in Debian to test with multiple Python versions, e.g. 3.11 and 3.12, not only with one that /usr/bin/sip-build uses.

Not sure if it will be useful for you, if not then no problem, I can carry a patch downstream.