### PR TITLE
Explicitly include sipbuild/module/source in the built tree

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,3 +3,4 @@ exclude .readthedocs.yaml
 prune docs
 prune examples
 prune test
+graft sipbuild/module/source


### PR DESCRIPTION
When building from a git repository checkout, setuptools_scm takes care of including all files that are present in the git repository.

However, when building from an unpacked archive, like we do in Debian, that is not the case, and without this patch `sipbuild/module/source` was not included in the resulting `.deb` package.