### PR TITLE
Include .git_archival.txt in the git-generated archives

### DIFF
--- a/.git_archival.txt
+++ b/.git_archival.txt
@@ -1,0 +1,3 @@
+node: $Format:%H$
+node-date: $Format:%cI$
+describe-name: $Format:%(describe:tags=true,match=*[0-9]*)$

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+.git_archival.txt export-subst


### PR DESCRIPTION
This file contains the necessary metadata for setuptools-scm, see <https://setuptools-scm.readthedocs.io/en/latest/usage/#git-archives>.