### PR TITLE
Removed redundant '%' in trace output of `this` pointer in code generator's write method.

### DIFF
--- a/sipbuild/generator/outputs/code.py
+++ b/sipbuild/generator/outputs/code.py
@@ -3810,7 +3810,7 @@ def _shadow_code(sf, spec, bindings, klass):
             args = fmt_signature_as_cpp_declaration(spec, ctor.cpp_signature,
                     scope=klass.iface_file)
 
-            sf.write(f'    sipTrace(SIP_TRACE_CTORS, "sip{klass_name}::sip{klass_name}({args}){throw_specifier} (this=0x%%08x)\\n", this);\n\n')
+            sf.write(f'    sipTrace(SIP_TRACE_CTORS, "sip{klass_name}::sip{klass_name}({args}){throw_specifier} (this=0x%08x)\\n", this);\n\n')
 
         if nr_virtuals > 0:
             sf.write('    memset(sipPyMethods, 0, sizeof (sipPyMethods));\n')
@@ -3824,7 +3824,7 @@ def _shadow_code(sf, spec, bindings, klass):
         sf.write(f'\nsip{klass_name}::~sip{klass_name}(){throw_specifier}\n{{\n')
 
         if bindings.tracing:
-            sf.write(f'    sipTrace(SIP_TRACE_DTORS, "sip{klass_name}::~sip{klass_name}(){throw_specifier} (this=0x%%08x)\\n", this);\n\n')
+            sf.write(f'    sipTrace(SIP_TRACE_DTORS, "sip{klass_name}::~sip{klass_name}(){throw_specifier} (this=0x%08x)\\n", this);\n\n')
 
         if klass.dtor_virtual_catcher_code is not None:
             sf.write_code(klass.dtor_virtual_catcher_code)
@@ -3940,7 +3940,7 @@ def _virtual_catcher(sf, spec, bindings, klass, virtual_overload, virt_nr):
     if bindings.tracing:
         args = fmt_signature_as_cpp_declaration(spec, overload.cpp_signature,
                 scope=klass.iface_file)
-        sf.write(f'    sipTrace(SIP_TRACE_CATCHERS, "{result_type} sip{klass_name}::{overload_cpp_name}({args}){const}{throw_specifier} (this=0x%%08x)\\n", this);\n\n')
+        sf.write(f'    sipTrace(SIP_TRACE_CATCHERS, "{result_type} sip{klass_name}::{overload_cpp_name}({args}){const}{throw_specifier} (this=0x%08x)\\n", this);\n\n')
 
     _restore_protections(protection_state)
 


### PR DESCRIPTION
Hello, after using `sip-build` to build PyQt5, I tried to use `sip.settracemask(0x008 | 0x002)` to output the address of `this` pointer during object construction. However, the console consistently outputs `(this=0x%08x)` instead of the expected address.

![image](https://github.com/user-attachments/assets/6b85b694-0339-4a6a-be15-9d91efcfde2b)

After investigating, I discovered that the issue originates from the `generator/outputs/code.py` file, where some lines like

```Python
sf.write(f'    sipTrace(SIP_TRACE_CTORS, "sip{klass_name}::sip{klass_name}({args}){throw_specifier} (this=0x%%08x)\\n", this);\n\n')
```

contain an extra `%` character. This is likely an oversight from the refactoring of the C code generator into a pure Python implementation (commit [56ec1de5](https://github.com/Python-SIP/sip/commit/56ec1de5c0763a1400e03bee8a71ffa821a1ffe6)), which caused the this pointer not to be output as expected.

This pull request removes the extra `%` character, ensuring that the address of `this` pointer is displayed correctly in the trace output. After this change, it works!

![image](https://github.com/user-attachments/assets/7d4c55ba-7edd-473d-a445-01f4f23e7fd7)

I hope this contribution helps improve the project.😄