### PR TITLE
Add deprecated decorator in pyi files

### DIFF
--- a/sipbuild/generator/outputs/pyi.py
+++ b/sipbuild/generator/outputs/pyi.py
@@ -61,6 +61,7 @@ def _module(pf, spec):
         first = _separate(pf, first=first)
         pf.write(
 f'''import typing
+from typing_extensions import deprecated
 
 import {spec.sip_module}
 ''')
@@ -518,6 +519,9 @@ def _overload(pf, spec, overload, overloaded, first_overload, is_method,
     if is_method and overload.is_static:
         pf.write(_indent(indent) + '@staticmethod\n')
 
+    if overload.deprecated_message:
+        pf.write(_indent(indent) + '@deprecated("""' + overload.deprecated_message + '""")\n')
+        
     py_name = overload.common.py_name.name
     py_signature = overload.py_signature
 

--- a/sipbuild/generator/parser/annotations.py
+++ b/sipbuild/generator/parser/annotations.py
@@ -125,8 +125,12 @@ def validate_name(pm, p, symbol, name, value, *, allow_dots, optional):
 name = bind(validate_name, allow_dots=False, optional=False)
 
 
-def validate_string(pm, p, symbol, name, value):
+def validate_string(pm, p, symbol, name, value, optional):
     """ Return a valid string value. """
+
+    if value is None:
+        if optional:
+            return ''
 
     if not isinstance(value, str):
         raise InvalidAnnotation(name, "must be a quoted string", use='')
@@ -149,7 +153,7 @@ def validate_string(pm, p, symbol, name, value):
     # No value was selected so ignore the annotation completely.
     return None
 
-string = bind(validate_string)
+string = bind(validate_string, optional=False)
 
 
 def validate_string_list(pm, p, symbol, name, value):
@@ -177,7 +181,7 @@ _ANNOTATION_TYPES = {
     'BaseType':                 name(),
     'Capsule':                  boolean(),
     'Constrained':              boolean(),
-    'Deprecated':               boolean(),
+    'Deprecated':               string(optional=True),
     'Default':                  boolean(),
     'DelayDtor':                boolean(),
     'DisallowNone':             boolean(),

--- a/sipbuild/generator/parser/parser_manager.py
+++ b/sipbuild/generator/parser/parser_manager.py
@@ -182,8 +182,9 @@ class ParserManager:
                 else:
                     klass.default_ctor = last_resort
 
-            klass.deprecated = annotations.get('Deprecated', False)
-
+            klass.deprecated = annotations.get('Deprecated') is not None
+            klass.deprecated_message = annotations.get('Deprecated')
+            
             if klass.convert_to_type_code is not None and annotations.get('AllowNone', False):
                 klass.handles_none = True
 
@@ -490,7 +491,8 @@ class ParserManager:
 
         ctor.docstring = docstring
         ctor.gil_action = self._get_gil_action(p, symbol, annotations)
-        ctor.deprecated = annotations.get('Deprecated', False)
+        ctor.deprecated = annotations.get('Deprecated') is not None
+        ctor.deprecated_message = annotations.get('Deprecated')
 
         if access_specifier is not AccessSpecifier.PRIVATE:
             ctor.kw_args = self._get_kw_args(p, symbol, annotations,
@@ -729,7 +731,8 @@ class ParserManager:
 
         overload.gil_action = self._get_gil_action(p, symbol, annotations)
         overload.factory = annotations.get('Factory', False)
-        overload.deprecated = annotations.get('Deprecated', False)
+        overload.deprecated = annotations.get('Deprecated') is not None
+        overload.deprecated_message = annotations.get('Deprecated')
         overload.new_thread = annotations.get('NewThread', False)
         overload.transfer = self.get_transfer(p, symbol, annotations)
 

--- a/sipbuild/generator/specification.py
+++ b/sipbuild/generator/specification.py
@@ -1074,6 +1074,9 @@ class Overload:
     # Set if /Deprecated/ was specified.
     deprecated: bool = False
 
+    # Set /Deprecated/ message if specificed.
+    deprecated_message: Optional[Docstring] = None
+    
     # The docstring.
     docstring: Optional[Docstring] = None
 
@@ -1493,6 +1496,9 @@ class WrappedClass:
 
     # Set if /Deprecated/ was specified.
     deprecated: bool = False
+
+    # Set /Deprecated/ message if specificed.
+    deprecated_message: Optional[Docstring] = None
 
     # The docstring.
     docstring: Optional[Docstring] = None


### PR DESCRIPTION
This Pull request proposes to:
- add an optionnal deprecated message to the /Deprecated/ annotation
- write down this message in a @deprecated decorator

It fixes #8 

This is still a draft because I would like to know if the project is opened to this contribution before going any further.

To be complete, this work would require to
- add some test ?
- have only one deprecated string variable and modify the code accordingly
- have a sip-build option switch --pep702 ?
- update doc
- write @deprecated() when there is no given message
- anything else? please let me know

I'm not aware of the release policy. So, if accepted, when this modification could land ? In next minor version ? Or do we have to wait for major version?