### PR TITLE
Add deprecated decorator

### DIFF
--- a/docs/annotations.rst
+++ b/docs/annotations.rst
@@ -398,7 +398,9 @@ Class Annotations
 
 .. class-annotation:: Deprecated
 
-    This boolean annotation is used to specify that the class is deprecated.
+    This string annotation is used to specify that the class is deprecated.
+    Deprecation message is optionnal and would be reported when a deprecation
+    warning is issued.
     It is the equivalent of annotating all the class's constructors, function
     and methods as being deprecated.
 
@@ -711,9 +713,10 @@ Function Annotations
 
 .. function-annotation:: Deprecated
 
-    This boolean annotation is used to specify that the constructor or function
-    is deprecated.  A deprecation warning is issued whenever the constructor or
-    function is called.
+    This string annotation is used to specify that the constructor or function
+    is deprecated. A deprecation warning is issued whenever the constructor or
+    function is called. Deprecation message is optionnal and would be reported
+    when a deprecation warning is issued.
 
 
 .. function-annotation:: DisallowNone

--- a/sipbuild/generator/outputs/code/code.py
+++ b/sipbuild/generator/outputs/code/code.py
@@ -6269,9 +6269,9 @@ def _constructor_call(sf, spec, bindings, klass, ctor, error_flag,
 
         if _abi_has_deprecated_message(spec):
             str_deprecated_message = f'''"{ctor.deprecated}"''' if ctor.deprecated else "NULL"
-            sf.write('            if (sipDeprecated({_cached_name_ref(klass.py_name)}, SIP_NULLPTR, {str_deprecated_message}) < 0)')
+            sf.write(f'            if (sipDeprecated({_cached_name_ref(klass.py_name)}, SIP_NULLPTR, {str_deprecated_message}) < 0)')
         else:
-            sf.write('            if (sipDeprecated({_cached_name_ref(klass.py_name)}, SIP_NULLPTR) < 0)')
+            sf.write(f'            if (sipDeprecated({_cached_name_ref(klass.py_name)}, SIP_NULLPTR) < 0)')
             
         sf.write(f'                return SIP_NULLPTR;')
 

--- a/sipbuild/generator/outputs/code/code.py
+++ b/sipbuild/generator/outputs/code/code.py
@@ -6247,8 +6247,10 @@ def _constructor_call(sf, spec, bindings, klass, ctor, error_flag,
 
     if ctor.deprecated:
         # Note that any temporaries will leak if an exception is raised.
+
+        str_deprecated_message = f'''"{ctor.deprecated_message}"''' if ctor.deprecated_message else "NULL"
         sf.write(
-f'''            if (sipDeprecated({_cached_name_ref(klass.py_name)}, SIP_NULLPTR) < 0)
+f'''            if (sipDeprecated({_cached_name_ref(klass.py_name)}, SIP_NULLPTR, {str_deprecated_message}) < 0)
                 return SIP_NULLPTR;
 
 ''')

--- a/sipbuild/generator/outputs/code/code.py
+++ b/sipbuild/generator/outputs/code/code.py
@@ -181,7 +181,6 @@ f'''
 #define sipConvertFromVoidPtrAndSize    sipAPI_{module_name}->api_convert_from_void_ptr_and_size
 #define sipConvertFromConstVoidPtrAndSize   sipAPI_{module_name}->api_convert_from_const_void_ptr_and_size
 #define sipWrappedTypeName(wt)      ((wt)->wt_td->td_cname)
-#define sipDeprecated               sipAPI_{module_name}->api_deprecated
 #define sipGetReference             sipAPI_{module_name}->api_get_reference
 #define sipKeepReference            sipAPI_{module_name}->api_keep_reference
 #define sipRegisterProxyResolver    sipAPI_{module_name}->api_register_proxy_resolver
@@ -242,6 +241,16 @@ f'''
 
     # These are dependent on the specific ABI version.
     if spec.abi_version >= (13, 0):
+        # ABI v13.9 and later
+        if spec.abi_version >= (13, 9):
+            sf.write(
+f'''#define sipDeprecated               sipAPI_{module_name}->api_deprecated_13_9
+''')
+        else:
+            sf.write(
+f'''#define sipDeprecated               sipAPI_{module_name}->api_deprecated
+''')
+                    
         # ABI v13.6 and later.
         if spec.abi_version >= (13, 6):
             sf.write(
@@ -253,7 +262,7 @@ f'''#define sipPyTypeDictRef            sipAPI_{module_name}->api_py_type_dict_r
             sf.write(
 f'''#define sipNextExceptionHandler     sipAPI_{module_name}->api_next_exception_handler
 ''')
-
+            
         # ABI v13.0 and later. */
         sf.write(
 f'''#define sipIsEnumFlag               sipAPI_{module_name}->api_is_enum_flag
@@ -262,6 +271,16 @@ f'''#define sipIsEnumFlag               sipAPI_{module_name}->api_is_enum_flag
 #define sipReleaseTypeUS            sipAPI_{module_name}->api_release_type_us
 ''')
     else:
+        # ABI v12.16 and later
+        if spec.abi_version >= (12, 16):
+            sf.write(
+f'''#define sipDeprecated               sipAPI_{module_name}->api_deprecated_12_16
+''')
+        else:
+            sf.write(
+f'''#define sipDeprecated               sipAPI_{module_name}->api_deprecated
+''')
+            
         # ABI v12.13 and later.
         if spec.abi_version >= (12, 13):
             sf.write(

--- a/sipbuild/generator/outputs/code/code.py
+++ b/sipbuild/generator/outputs/code/code.py
@@ -7084,10 +7084,11 @@ f'''            if (!sipOrigSelf)
     if overload.deprecated:
         scope_py_name_ref = _cached_name_ref(scope.py_name) if scope is not None and scope.py_name is not None else 'SIP_NULLPTR'
         error_return = '-1' if is_void_return_slot(py_slot) or is_int_return_slot(py_slot) or is_ssize_return_slot(py_slot) or is_hash_return_slot(py_slot) else 'SIP_NULLPTR'
-
+        str_deprecated_message = f'''"{overload.deprecated_message}"''' if overload.deprecated_message else "NULL"
+        
         # Note that any temporaries will leak if an exception is raised.
         sf.write(
-f'''            if (sipDeprecated({scope_py_name_ref}, {_cached_name_ref(overload.common.py_name)}) < 0)
+f'''            if (sipDeprecated({scope_py_name_ref}, {_cached_name_ref(overload.common.py_name)}, {str_deprecated_message}) < 0)
                 return {error_return};
 
 ''')

--- a/sipbuild/generator/outputs/code/code.py
+++ b/sipbuild/generator/outputs/code/code.py
@@ -6264,11 +6264,11 @@ def _constructor_call(sf, spec, bindings, klass, ctor, error_flag,
     elif old_error_flag:
         sf.write('            int sipIsErr = 0;\n\n')
 
-    if ctor.deprecated:
+    if ctor.deprecated is not None:
         # Note that any temporaries will leak if an exception is raised.
 
         if _abi_has_deprecated_message(spec):
-            str_deprecated_message = f'''"{ctor.deprecated_message}"''' if ctor.deprecated_message else "NULL"
+            str_deprecated_message = f'''"{ctor.deprecated}"''' if ctor.deprecated else "NULL"
             sf.write('            if (sipDeprecated({_cached_name_ref(klass.py_name)}, SIP_NULLPTR, {str_deprecated_message}) < 0)')
         else:
             sf.write('            if (sipDeprecated({_cached_name_ref(klass.py_name)}, SIP_NULLPTR) < 0)')
@@ -7103,13 +7103,13 @@ f'''            if (!sipOrigSelf)
 
 ''')
 
-    if overload.deprecated:
+    if overload.deprecated is not None:
         scope_py_name_ref = _cached_name_ref(scope.py_name) if scope is not None and scope.py_name is not None else 'SIP_NULLPTR'
         error_return = '-1' if is_void_return_slot(py_slot) or is_int_return_slot(py_slot) or is_ssize_return_slot(py_slot) or is_hash_return_slot(py_slot) else 'SIP_NULLPTR'
 
         # Note that any temporaries will leak if an exception is raised.
         if _abi_has_deprecated_message(spec):
-            str_deprecated_message = f'''"{overload.deprecated_message}"''' if overload.deprecated_message else "NULL"
+            str_deprecated_message = f'''"{overload.deprecated}"''' if overload.deprecated else "NULL"
             sf.write(f'            if (sipDeprecated({scope_py_name_ref}, {_cached_name_ref(overload.common.py_name)}, {str_deprecated_message}) < 0)')
         else:
             sf.write(f'            if (sipDeprecated({scope_py_name_ref}, {_cached_name_ref(overload.common.py_name)}) < 0)')

--- a/sipbuild/generator/outputs/pyi.py
+++ b/sipbuild/generator/outputs/pyi.py
@@ -177,8 +177,7 @@ def _class(pf, spec, klass, defined, indent=0):
         s = _indent(indent)
 
         if klass.deprecated is not None:
-            deprecated_message = f'"""{klass.deprecated}"""'
-            s += f'@deprecated({deprecated_message})\n' + _indent(indent)
+            s += f'@deprecated("{klass.deprecated}")\n' + _indent(indent)
 
         s += f'class {klass.py_name.name}('
 

--- a/sipbuild/generator/outputs/pyi.py
+++ b/sipbuild/generator/outputs/pyi.py
@@ -526,8 +526,8 @@ def _overload(pf, spec, overload, overloaded, first_overload, is_method,
     if is_method and overload.is_static:
         pf.write(_indent(indent) + '@staticmethod\n')
 
-    if overload.deprecated:
-        deprecated_message = f'"""{overload.deprecated_message}"""'  if overload.deprecated_message else ""
+    if overload.deprecated is not None:
+        deprecated_message = f'"""{overload.deprecated}"""'
         pf.write(_indent(indent) + f'@deprecated({deprecated_message})\n')
         
     py_name = overload.common.py_name.name

--- a/sipbuild/generator/outputs/pyi.py
+++ b/sipbuild/generator/outputs/pyi.py
@@ -61,7 +61,14 @@ def _module(pf, spec):
     if stdlib_imports:
         first = _separate(pf, first=first)
         pf.write('import ' + ', '.join(stdlib_imports) + '\n')
-
+        pf.write(
+f'''
+try:
+    from warnings import deprecated
+except ImportError:
+    pass
+''')
+            
     if spec.sip_module:
         first = _separate(pf, first=first, minimum=1)
         pf.write(f'import {spec.sip_module}\n')
@@ -519,6 +526,10 @@ def _overload(pf, spec, overload, overloaded, first_overload, is_method,
     if is_method and overload.is_static:
         pf.write(_indent(indent) + '@staticmethod\n')
 
+    if overload.deprecated:
+        deprecated_message = f'"""{overload.deprecated_message}"""'  if overload.deprecated_message else ""
+        pf.write(_indent(indent) + f'@deprecated({deprecated_message})\n')
+        
     py_name = overload.common.py_name.name
     py_signature = overload.py_signature
 

--- a/sipbuild/generator/outputs/pyi.py
+++ b/sipbuild/generator/outputs/pyi.py
@@ -336,6 +336,10 @@ def _ctor(pf, spec, ctor, overloaded, defined, indent):
         s += '@typing.overload\n'
         pf.write(s)
 
+    if ctor.deprecated is not None:
+        deprecated_message = f'"""{ctor.deprecated}"""'
+        pf.write(_indent(indent) + f'@deprecated({deprecated_message})\n')
+        
     s = _indent(indent)
     s += 'def __init__'
     s += _python_signature(spec, ctor.py_signature, defined)

--- a/sipbuild/generator/outputs/pyi.py
+++ b/sipbuild/generator/outputs/pyi.py
@@ -176,6 +176,10 @@ def _class(pf, spec, klass, defined, indent=0):
 
         s = _indent(indent)
 
+        if klass.deprecated is not None:
+            deprecated_message = f'"""{klass.deprecated}"""'
+            s += f'@deprecated({deprecated_message})\n' + _indent(indent)
+
         s += f'class {klass.py_name.name}('
 
         if klass.superclasses:

--- a/sipbuild/generator/parser/annotations.py
+++ b/sipbuild/generator/parser/annotations.py
@@ -126,7 +126,7 @@ name = bind(validate_name, allow_dots=False, optional=False)
 
 
 def validate_string(pm, p, symbol, name, value, optional):
-    """ Return a valid string value. """
+    """ Return a valid, possibly optional, string value. """
 
     if value is None:
         if optional:

--- a/sipbuild/generator/parser/annotations.py
+++ b/sipbuild/generator/parser/annotations.py
@@ -125,8 +125,12 @@ def validate_name(pm, p, symbol, name, value, *, allow_dots, optional):
 name = bind(validate_name, allow_dots=False, optional=False)
 
 
-def validate_string(pm, p, symbol, name, value):
+def validate_string(pm, p, symbol, name, value, optional):
     """ Return a valid string value. """
+
+    if value is None:
+        if optional:
+            return ''
 
     if not isinstance(value, str):
         raise InvalidAnnotation(name, "must be a quoted string", use='')
@@ -149,7 +153,7 @@ def validate_string(pm, p, symbol, name, value):
     # No value was selected so ignore the annotation completely.
     return None
 
-string = bind(validate_string)
+string = bind(validate_string, optional=False)
 
 
 def validate_string_list(pm, p, symbol, name, value):
@@ -177,7 +181,7 @@ _ANNOTATION_TYPES = {
     'BaseType':                 name(),
     'Capsule':                  boolean(),
     'Constrained':              boolean(),
-    'Deprecated':               boolean(),
+    'Deprecated':               string(optional=True),
     'Default':                  boolean(),
     'DelayDtor':                boolean(),
     'DisallowNone':             boolean(),

--- a/sipbuild/generator/parser/parser_manager.py
+++ b/sipbuild/generator/parser/parser_manager.py
@@ -190,11 +190,8 @@ class ParserManager:
                         last_resort = ctor
                 else:
                     klass.default_ctor = last_resort
-
-            klass.deprecated = annotations.get('Deprecated')
-            if not _abi_has_deprecated_message(self.spec) and klass.deprecated:
-                self.parser_error(p, symbol,
-                        "/Deprecated/ supports message argument only for ABI v13.9 and later, or v12.16 or later")
+                    
+            klass.deprecated = annotations.get('Deprecated', False)
             
             if klass.convert_to_type_code is not None and annotations.get('AllowNone', False):
                 klass.handles_none = True

--- a/sipbuild/generator/parser/parser_manager.py
+++ b/sipbuild/generator/parser/parser_manager.py
@@ -190,9 +190,12 @@ class ParserManager:
                         last_resort = ctor
                 else:
                     klass.default_ctor = last_resort
-                    
-            klass.deprecated = annotations.get('Deprecated', False)
-            
+
+            klass.deprecated = annotations.get('Deprecated')
+            if not _abi_has_deprecated_message(self.spec) and klass.deprecated:
+                self.parser_error(p, symbol,
+                                  "/Deprecated/ supports message argument only for ABI v13.9 and later, or v12.16 or later")
+
             if klass.convert_to_type_code is not None and annotations.get('AllowNone', False):
                 klass.handles_none = True
 

--- a/sipbuild/generator/parser/parser_manager.py
+++ b/sipbuild/generator/parser/parser_manager.py
@@ -182,8 +182,9 @@ class ParserManager:
                 else:
                     klass.default_ctor = last_resort
 
-            klass.deprecated = annotations.get('Deprecated', False)
-
+            klass.deprecated = annotations.get('Deprecated') is not None
+            klass.deprecated_message = annotations.get('Deprecated')
+            
             if klass.convert_to_type_code is not None and annotations.get('AllowNone', False):
                 klass.handles_none = True
 
@@ -490,7 +491,8 @@ class ParserManager:
 
         ctor.docstring = docstring
         ctor.gil_action = self._get_gil_action(p, symbol, annotations)
-        ctor.deprecated = annotations.get('Deprecated', False)
+        ctor.deprecated = annotations.get('Deprecated') is not None
+        ctor.deprecated_message = annotations.get('Deprecated')
 
         if access_specifier is not AccessSpecifier.PRIVATE:
             ctor.kw_args = self._get_kw_args(p, symbol, annotations,
@@ -729,7 +731,8 @@ class ParserManager:
 
         overload.gil_action = self._get_gil_action(p, symbol, annotations)
         overload.factory = annotations.get('Factory', False)
-        overload.deprecated = annotations.get('Deprecated', False)
+        overload.deprecated_message = annotations.get('Deprecated')
+        overload.deprecated = overload.deprecated_message is not None
         overload.new_thread = annotations.get('NewThread', False)
         overload.transfer = self.get_transfer(p, symbol, annotations)
 

--- a/sipbuild/generator/parser/parser_manager.py
+++ b/sipbuild/generator/parser/parser_manager.py
@@ -182,8 +182,8 @@ class ParserManager:
                 else:
                     klass.default_ctor = last_resort
 
-            klass.deprecated = annotations.get('Deprecated') is not None
             klass.deprecated_message = annotations.get('Deprecated')
+            klass.deprecated = klass.deprecated_message is not None
             
             if klass.convert_to_type_code is not None and annotations.get('AllowNone', False):
                 klass.handles_none = True
@@ -491,8 +491,8 @@ class ParserManager:
 
         ctor.docstring = docstring
         ctor.gil_action = self._get_gil_action(p, symbol, annotations)
-        ctor.deprecated = annotations.get('Deprecated') is not None
         ctor.deprecated_message = annotations.get('Deprecated')
+        ctor.deprecated = ctor.deprecated_message is not None
 
         if access_specifier is not AccessSpecifier.PRIVATE:
             ctor.kw_args = self._get_kw_args(p, symbol, annotations,

--- a/sipbuild/generator/parser/parser_manager.py
+++ b/sipbuild/generator/parser/parser_manager.py
@@ -22,22 +22,12 @@ from ..specification import (AccessSpecifier, Argument, ArgumentType,
         WrappedException, WrappedEnum, WrappedEnumMember)
 from ..templates import encoded_template_name, same_template_signature
 from ..utils import (argument_as_str, cached_name, find_iface_file,
-        normalised_scoped_name, same_base_type)
+                     normalised_scoped_name, same_base_type, abi_has_deprecated_message)
 
 from . import rules
 from . import tokens
 from .annotations import InvalidAnnotation, validate_annotation_value
 from .ply import lex, yacc
-
-def _abi_has_deprecated_message(spec):
-    """ Return True if the ABI implements sipDeprecated() with message. """
-
-    return _abi_version_check(spec, (12, 16), (13, 9))
-
-def _abi_version_check(spec, min_12, min_13):
-    """ Return True if the ABI version meets minimum version requirements. """
-
-    return spec.abi_version >= min_13 or (min_12 <= spec.abi_version < (13, 0))
 
 class ParserManager:
     """ This object manages the actual lexer and parser objects providing them
@@ -192,7 +182,7 @@ class ParserManager:
                     klass.default_ctor = last_resort
 
             klass.deprecated = annotations.get('Deprecated')
-            if not _abi_has_deprecated_message(self.spec) and klass.deprecated:
+            if not abi_has_deprecated_message(self.spec) and klass.deprecated:
                 self.parser_error(p, symbol,
                                   "/Deprecated/ supports message argument only for ABI v13.9 and later, or v12.16 or later")
 
@@ -503,7 +493,7 @@ class ParserManager:
         ctor.docstring = docstring
         ctor.gil_action = self._get_gil_action(p, symbol, annotations)
         ctor.deprecated = annotations.get('Deprecated')
-        if not _abi_has_deprecated_message(self.spec) and ctor.deprecated:
+        if not abi_has_deprecated_message(self.spec) and ctor.deprecated:
             self.parser_error(p, symbol,
                               "/Deprecated/ supports message argument only for ABI v13.9 and later, or v12.16 or later")
 
@@ -745,7 +735,7 @@ class ParserManager:
         overload.gil_action = self._get_gil_action(p, symbol, annotations)
         overload.factory = annotations.get('Factory', False)
         overload.deprecated = annotations.get('Deprecated')
-        if not _abi_has_deprecated_message(self.spec) and overload.deprecated:
+        if not abi_has_deprecated_message(self.spec) and overload.deprecated:
             self.parser_error(p, symbol,
                               "/Deprecated/ supports message argument only for ABI v13.9 and later, or v12.16 or later")
 

--- a/sipbuild/generator/parser/parser_manager.py
+++ b/sipbuild/generator/parser/parser_manager.py
@@ -182,8 +182,7 @@ class ParserManager:
                 else:
                     klass.default_ctor = last_resort
 
-            klass.deprecated_message = annotations.get('Deprecated')
-            klass.deprecated = klass.deprecated_message is not None
+            klass.deprecated = annotations.get('Deprecated')
             
             if klass.convert_to_type_code is not None and annotations.get('AllowNone', False):
                 klass.handles_none = True
@@ -491,8 +490,7 @@ class ParserManager:
 
         ctor.docstring = docstring
         ctor.gil_action = self._get_gil_action(p, symbol, annotations)
-        ctor.deprecated_message = annotations.get('Deprecated')
-        ctor.deprecated = ctor.deprecated_message is not None
+        ctor.deprecated = annotations.get('Deprecated')
 
         if access_specifier is not AccessSpecifier.PRIVATE:
             ctor.kw_args = self._get_kw_args(p, symbol, annotations,
@@ -731,8 +729,7 @@ class ParserManager:
 
         overload.gil_action = self._get_gil_action(p, symbol, annotations)
         overload.factory = annotations.get('Factory', False)
-        overload.deprecated_message = annotations.get('Deprecated')
-        overload.deprecated = overload.deprecated_message is not None
+        overload.deprecated = annotations.get('Deprecated')
         overload.new_thread = annotations.get('NewThread', False)
         overload.transfer = self.get_transfer(p, symbol, annotations)
 

--- a/sipbuild/generator/resolver/resolver.py
+++ b/sipbuild/generator/resolver/resolver.py
@@ -649,8 +649,8 @@ def _set_mro(spec, klass, error_log, seen=None):
     if klass.scope is not None:
         _set_mro(spec, klass.scope, error_log, seen=seen)
 
-        if klass.scope.deprecated:
-            klass.deprecated = True
+        if klass.scope.deprecated and not klass.deprecated :
+            klass.deprecated = klass.scope.deprecated
 
     if klass.iface_file.type is IfaceFileType.CLASS:
         # The first thing is itself.
@@ -687,8 +687,11 @@ def _set_mro(spec, klass, error_log, seen=None):
                 if klass.iface_file.module is spec.module:
                     superklass_mro.iface_file.needed = True
 
-                if superklass_mro.deprecated:
-                    klass.deprecated = True
+                if scope.deprecated and not overload.deprecated :
+                    overload.deprecated = scope.deprecated
+
+                if superklass_mro.deprecated and not klass.deprecated:
+                    klass.deprecated = superklass_mro.deprecated
 
                 # If the super-class is a QObject sub-class then this one is as
                 # well.
@@ -816,8 +819,8 @@ def _resolve_ctors(spec, klass, error_log):
                                     klass.iface_file.fq_cpp_name))
                     break
 
-        if klass.deprecated:
-            ctor.deprecated = True
+        if klass.deprecated and not ctor.deprecated :
+            ctor.deprecated = klass.deprecated
 
 
 def _transform_casts(spec, klass, error_log):
@@ -872,9 +875,9 @@ def _add_default_copy_ctor(klass):
     signature = Signature(args=[arg], result=result)
     ctor = Constructor(AccessSpecifier.PUBLIC, py_signature=signature,
             cpp_signature=signature)
- 
-    if klass.deprecated:
-        ctor.deprecated = True
+
+    if klass.deprecated and not ctor.deprecated :
+        ctor.deprecated = klass.deprecated
 
     if not klass.is_abstract:
         klass.can_create = True
@@ -919,8 +922,9 @@ def _resolve_scope_overloads(spec, overloads, error_log, final_checks,
                     break
 
         if isinstance(scope, WrappedClass):
-            if scope.deprecated:
-                overload.deprecated = True
+            
+            if scope.deprecated and not overload.deprecated :
+                overload.deprecated = scope.deprecated
 
             if overload.is_abstract:
                 scope.is_abstract = True

--- a/sipbuild/generator/specification.py
+++ b/sipbuild/generator/specification.py
@@ -692,9 +692,6 @@ class Constructor:
     # deprecated message if /Deprecated/ was specified.
     deprecated: Optional[str] = None
 
-    # Set /Deprecated/ message if specificed.
-    deprecated_message: Optional['Docstring'] = None
-
     # The docstring.
     docstring: Optional['Docstring'] = None
 
@@ -1496,9 +1493,6 @@ class WrappedClass:
 
     # Set if /Deprecated/ was specified.
     deprecated: bool = False
-
-    # Set /Deprecated/ message if specificed.
-    deprecated_message: Optional[Docstring] = None
 
     # The docstring.
     docstring: Optional[Docstring] = None

--- a/sipbuild/generator/specification.py
+++ b/sipbuild/generator/specification.py
@@ -689,8 +689,8 @@ class Constructor:
     # The C/C++ signature.  It will be none if /NoDerived/ was specified.
     cpp_signature: Optional['Signature'] = None
 
-    # Set if /Deprecated/ was specified.
-    deprecated: bool = False
+    # deprecated message if /Deprecated/ was specified.
+    deprecated: Optional[str] = None
 
     # Set /Deprecated/ message if specificed.
     deprecated_message: Optional['Docstring'] = None
@@ -1074,11 +1074,8 @@ class Overload:
     # Set if the overload is really protected.
     access_is_really_protected: bool = False
 
-    # Set if /Deprecated/ was specified.
-    deprecated: bool = False
-
-    # Set /Deprecated/ message if specificed.
-    deprecated_message: Optional[Docstring] = None
+    # deprecated message if /Deprecated/ was specified.
+    deprecated: Optional[str] = None
     
     # The docstring.
     docstring: Optional[Docstring] = None

--- a/sipbuild/generator/specification.py
+++ b/sipbuild/generator/specification.py
@@ -692,6 +692,9 @@ class Constructor:
     # Set if /Deprecated/ was specified.
     deprecated: bool = False
 
+    # Set /Deprecated/ message if specificed.
+    deprecated_message: Optional['Docstring'] = None
+
     # The docstring.
     docstring: Optional['Docstring'] = None
 

--- a/sipbuild/generator/specification.py
+++ b/sipbuild/generator/specification.py
@@ -1074,6 +1074,9 @@ class Overload:
     # Set if /Deprecated/ was specified.
     deprecated: bool = False
 
+    # Set /Deprecated/ message if specificed.
+    deprecated_message: Optional[Docstring] = None
+    
     # The docstring.
     docstring: Optional[Docstring] = None
 
@@ -1493,6 +1496,9 @@ class WrappedClass:
 
     # Set if /Deprecated/ was specified.
     deprecated: bool = False
+
+    # Set /Deprecated/ message if specificed.
+    deprecated_message: Optional[Docstring] = None
 
     # The docstring.
     docstring: Optional[Docstring] = None

--- a/sipbuild/generator/specification.py
+++ b/sipbuild/generator/specification.py
@@ -1491,8 +1491,8 @@ class WrappedClass:
     # Set if /DelayDtor/ was specified.
     delay_dtor: bool = False
 
-    # Set if /Deprecated/ was specified.
-    deprecated: bool = False
+    # deprecated message if /Deprecated/ was specified.
+    deprecated: Optional[str] = None
 
     # The docstring.
     docstring: Optional[Docstring] = None

--- a/sipbuild/generator/utils.py
+++ b/sipbuild/generator/utils.py
@@ -485,3 +485,14 @@ def search_typedefs(spec, cpp_name, type):
     # Remember the original typedef.
     if type.original_typedef is None:
         type.original_typedef = typedef
+
+        
+def abi_version_check(spec, min_12, min_13):
+    """ Return True if the ABI version meets minimum version requirements. """
+
+    return spec.abi_version >= min_13 or (min_12 <= spec.abi_version < (13, 0))
+
+def abi_has_deprecated_message(spec):
+    """ Return True if the ABI implements sipDeprecated() with message. """
+
+    return abi_version_check(spec, (12, 16), (13, 9))

--- a/sipbuild/module/source/12/apiversions.c
+++ b/sipbuild/module/source/12/apiversions.c
@@ -178,7 +178,7 @@ PyObject *sipGetAPI(PyObject *self, PyObject *args)
 
     (void)self;
 
-    if (sip_api_deprecated(NULL, "getapi", NULL) < 0)
+    if (sip_api_deprecated(NULL, "getapi") < 0)
         return NULL;
 
     if (!PyArg_ParseTuple(args, "s:getapi", &api))
@@ -205,7 +205,7 @@ PyObject *sipSetAPI(PyObject *self, PyObject *args)
 
     (void)self;
 
-    if (sip_api_deprecated(NULL, "setapi", NULL) < 0)
+    if (sip_api_deprecated(NULL, "setapi") < 0)
         return NULL;
 
     if (!PyArg_ParseTuple(args, "si:setapi", &api, &version_nr))

--- a/sipbuild/module/source/12/apiversions.c
+++ b/sipbuild/module/source/12/apiversions.c
@@ -178,9 +178,6 @@ PyObject *sipGetAPI(PyObject *self, PyObject *args)
 
     (void)self;
 
-    if (sip_api_deprecated(NULL, "getapi") < 0)
-        return NULL;
-
     if (!PyArg_ParseTuple(args, "s:getapi", &api))
         return NULL;
 
@@ -204,9 +201,6 @@ PyObject *sipSetAPI(PyObject *self, PyObject *args)
     const apiVersionDef *avd;
 
     (void)self;
-
-    if (sip_api_deprecated(NULL, "setapi") < 0)
-        return NULL;
 
     if (!PyArg_ParseTuple(args, "si:setapi", &api, &version_nr))
         return NULL;

--- a/sipbuild/module/source/12/apiversions.c
+++ b/sipbuild/module/source/12/apiversions.c
@@ -178,7 +178,7 @@ PyObject *sipGetAPI(PyObject *self, PyObject *args)
 
     (void)self;
 
-    if (sip_api_deprecated(NULL, "getapi") < 0)
+    if (sip_api_deprecated(NULL, "getapi", NULL) < 0)
         return NULL;
 
     if (!PyArg_ParseTuple(args, "s:getapi", &api))
@@ -205,7 +205,7 @@ PyObject *sipSetAPI(PyObject *self, PyObject *args)
 
     (void)self;
 
-    if (sip_api_deprecated(NULL, "setapi") < 0)
+    if (sip_api_deprecated(NULL, "setapi", NULL) < 0)
         return NULL;
 
     if (!PyArg_ParseTuple(args, "si:setapi", &api, &version_nr))

--- a/sipbuild/module/source/12/sip.h.in
+++ b/sipbuild/module/source/12/sip.h.in
@@ -1682,7 +1682,7 @@ typedef struct _sipAPIDef {
     PyObject *(*api_py_type_dict_ref)(PyTypeObject *);
 
     /*
-     * The following are part of the public API.
+     * The following are part of the private API.
      */
     int (*api_deprecated_12_16)(const char *classname, const char *method, const char *message);
 

--- a/sipbuild/module/source/12/sip.h.in
+++ b/sipbuild/module/source/12/sip.h.in
@@ -44,6 +44,7 @@ extern "C" {
  *
  * v12.16
  *  - Python v3.9 or later is required.
+ *  - Add the possibility to define a message to Deprecated annotation and generate @deprecated macro in pyi files
  *
  * v12.15
  *  - Added the 'I' conversion character to the argument and result parsers.

--- a/sipbuild/module/source/12/sip.h.in
+++ b/sipbuild/module/source/12/sip.h.in
@@ -1575,7 +1575,7 @@ typedef struct _sipAPIDef {
     int (*api_unicode_as_wchar)(PyObject *obj);
     int *(*api_unicode_as_wstring)(PyObject *obj);
 #endif
-    int (*api_deprecated)(const char *classname, const char *method, const char *message);
+    int (*api_deprecated)(const char *classname, const char *method);
     void (*api_keep_reference)(PyObject *self, int key, PyObject *obj);
     int (*api_parse_kwd_args)(PyObject **parseErrp, PyObject *sipArgs,
             PyObject *sipKwdArgs, const char **kwdlist, PyObject **unused,
@@ -1679,6 +1679,12 @@ typedef struct _sipAPIDef {
      * The following are part of the public API.
      */
     PyObject *(*api_py_type_dict_ref)(PyTypeObject *);
+
+    /*
+     * The following are part of the public API.
+     */
+    int (*api_deprecated_12_16)(const char *classname, const char *method, const char *message);
+
 } sipAPIDef;
 
 const sipAPIDef *sip_init_library(PyObject *mod_dict);

--- a/sipbuild/module/source/12/sip.h.in
+++ b/sipbuild/module/source/12/sip.h.in
@@ -1575,7 +1575,7 @@ typedef struct _sipAPIDef {
     int (*api_unicode_as_wchar)(PyObject *obj);
     int *(*api_unicode_as_wstring)(PyObject *obj);
 #endif
-    int (*api_deprecated)(const char *classname, const char *method);
+    int (*api_deprecated)(const char *classname, const char *method, const char *message);
     void (*api_keep_reference)(PyObject *self, int key, PyObject *obj);
     int (*api_parse_kwd_args)(PyObject **parseErrp, PyObject *sipArgs,
             PyObject *sipKwdArgs, const char **kwdlist, PyObject **unused,

--- a/sipbuild/module/source/12/sipint.h
+++ b/sipbuild/module/source/12/sipint.h
@@ -150,7 +150,8 @@ int sip_api_save_slot(sipSlot *sp, PyObject *rxObj, const char *slot);
 int sip_api_convert_from_slice_object(PyObject *slice, Py_ssize_t length,
         Py_ssize_t *start, Py_ssize_t *stop, Py_ssize_t *step,
         Py_ssize_t *slicelength);
-int sip_api_deprecated(const char *classname, const char *method, const char *message);
+int sip_api_deprecated(const char *classname, const char *method);
+int sip_api_deprecated_12_16(const char *classname, const char *method, const char *message);
 
 
 /*

--- a/sipbuild/module/source/12/sipint.h
+++ b/sipbuild/module/source/12/sipint.h
@@ -150,7 +150,7 @@ int sip_api_save_slot(sipSlot *sp, PyObject *rxObj, const char *slot);
 int sip_api_convert_from_slice_object(PyObject *slice, Py_ssize_t length,
         Py_ssize_t *start, Py_ssize_t *stop, Py_ssize_t *step,
         Py_ssize_t *slicelength);
-int sip_api_deprecated(const char *classname, const char *method);
+int sip_api_deprecated(const char *classname, const char *method, const char *message);
 
 
 /*

--- a/sipbuild/module/source/12/siplib.c
+++ b/sipbuild/module/source/12/siplib.c
@@ -604,6 +604,10 @@ static const sipAPIDef sip_api = {
      * The following are part of the public API.
      */
     sip_api_py_type_dict_ref,
+    /*
+     * The following are part of the public API.
+     */
+    sip_api_deprecated_12_16,
 };
 
 
@@ -7772,11 +7776,18 @@ static void sip_api_abstract_method(const char *classname, const char *method)
             classname, method);
 }
 
+/*
+ * Report a deprecated class or method.
+ */
+int sip_api_deprecated(const char *classname, const char *method)
+{
+  return sip_api_deprecated_12_16( classname, method, NULL );
+}
 
 /*
  * Report a deprecated class or method with a given message.
  */
-int sip_api_deprecated(const char *classname, const char *method, const char *message)
+int sip_api_deprecated_12_16(const char *classname, const char *method, const char *message)
 {
     const unsigned int bufsize = 100 + ( message ? strlen(message) : 0 );
     char buf[bufsize];

--- a/sipbuild/module/source/12/siplib.c
+++ b/sipbuild/module/source/12/siplib.c
@@ -7774,11 +7774,12 @@ static void sip_api_abstract_method(const char *classname, const char *method)
 
 
 /*
- * Report a deprecated class or method.
+ * Report a deprecated class or method with a given message.
  */
-int sip_api_deprecated(const char *classname, const char *method)
+int sip_api_deprecated(const char *classname, const char *method, const char *message)
 {
-    char buf[100];
+    const unsigned int bufsize = 100 + ( message ? strlen(message) : 0 );
+    char buf[bufsize];
 
     if (classname == NULL)
         PyOS_snprintf(buf, sizeof (buf), "%s() is deprecated", method);
@@ -7786,8 +7787,13 @@ int sip_api_deprecated(const char *classname, const char *method)
         PyOS_snprintf(buf, sizeof (buf), "%s constructor is deprecated",
                 classname);
     else
-        PyOS_snprintf(buf, sizeof (buf), "%s.%s() is deprecated", classname,
-                method);
+        PyOS_snprintf(buf, sizeof (buf), "%s.%s() is deprecated", classname, method);
+
+    if ( message )
+    {
+      int i = strlen(buf);
+      PyOS_snprintf(buf+i, sizeof (buf), " : %s", message);
+    }
 
     return PyErr_WarnEx(PyExc_DeprecationWarning, buf, 1);
 }

--- a/sipbuild/module/source/12/siplib.c
+++ b/sipbuild/module/source/12/siplib.c
@@ -7800,11 +7800,8 @@ int sip_api_deprecated_12_16(const char *classname, const char *method, const ch
     else
         PyOS_snprintf(buf, sizeof (buf), "%s.%s() is deprecated", classname, method);
 
-    if ( message )
-    {
-      int i = strlen(buf);
-      PyOS_snprintf(buf+i, sizeof (buf), " : %s", message);
-    }
+    if (message != NULL)
+      PyOS_snprintf(&buf[strlen(buf)], sizeof (buf), ": %s", message);
 
     return PyErr_WarnEx(PyExc_DeprecationWarning, buf, 1);
 }

--- a/sipbuild/module/source/12/siplib.c
+++ b/sipbuild/module/source/12/siplib.c
@@ -605,7 +605,7 @@ static const sipAPIDef sip_api = {
      */
     sip_api_py_type_dict_ref,
     /*
-     * The following are part of the public API.
+     * The following are part of the private API.
      */
     sip_api_deprecated_12_16,
 };

--- a/sipbuild/module/source/13/sip.h.in
+++ b/sipbuild/module/source/13/sip.h.in
@@ -1409,7 +1409,7 @@ typedef struct _sipAPIDef {
     int (*api_unicode_as_wchar)(PyObject *obj);
     int *(*api_unicode_as_wstring)(PyObject *obj);
 #endif
-    int (*api_deprecated)(const char *classname, const char *method);
+    int (*api_deprecated)(const char *classname, const char *method, const char *message);
     void (*api_keep_reference)(PyObject *self, int key, PyObject *obj);
     int (*api_parse_kwd_args)(PyObject **parseErrp, PyObject *sipArgs,
             PyObject *sipKwdArgs, const char **kwdlist, PyObject **unused,

--- a/sipbuild/module/source/13/sip.h.in
+++ b/sipbuild/module/source/13/sip.h.in
@@ -1409,7 +1409,7 @@ typedef struct _sipAPIDef {
     int (*api_unicode_as_wchar)(PyObject *obj);
     int *(*api_unicode_as_wstring)(PyObject *obj);
 #endif
-    int (*api_deprecated)(const char *classname, const char *method, const char *message);
+    int (*api_deprecated)(const char *classname, const char *method);
     void (*api_keep_reference)(PyObject *self, int key, PyObject *obj);
     int (*api_parse_kwd_args)(PyObject **parseErrp, PyObject *sipArgs,
             PyObject *sipKwdArgs, const char **kwdlist, PyObject **unused,
@@ -1428,7 +1428,7 @@ typedef struct _sipAPIDef {
     PyObject *(*api_is_py_method_12_8)(sip_gilstate_t *gil, char *pymc,
             sipSimpleWrapper **sipSelfp, const char *cname, const char *mname);
     sipExceptionHandler (*api_next_exception_handler)(void **statep);
-    void (*unused_private_2)(void);
+    int (*api_deprecated_13_9)(const char *classname, const char *method, const char *message);
     void (*unused_private_3)(void);
     void (*unused_private_4)(void);
     void (*unused_private_5)(void);

--- a/sipbuild/module/source/13/sip.h.in
+++ b/sipbuild/module/source/13/sip.h.in
@@ -44,6 +44,7 @@ extern "C" {
  *
  * v13.9
  *  - Python v3.9 or later is required.
+ *  - Add the possibility to define a message to Deprecated annotation and generate @deprecated macro in pyi files
  *
  * v13.8
  *  - Added the 'I' conversion character to the argument and result parsers.

--- a/sipbuild/module/source/13/sip_core.c
+++ b/sipbuild/module/source/13/sip_core.c
@@ -6685,11 +6685,8 @@ int sip_api_deprecated_13_9(const char *classname, const char *method, const cha
     else
       PyOS_snprintf(buf, sizeof (buf), "%s.%s() is deprecated", classname, method );
 
-    if ( message )
-    {
-      int i = strlen(buf);
-      PyOS_snprintf(buf+i, sizeof (buf), " : %s", message);
-    }
+    if (message != NULL)
+      PyOS_snprintf(&buf[strlen(buf)], sizeof (buf), ": %s", message);
 
     return PyErr_WarnEx(PyExc_DeprecationWarning, buf, 1);
 }

--- a/sipbuild/module/source/13/sip_core.c
+++ b/sipbuild/module/source/13/sip_core.c
@@ -6661,13 +6661,13 @@ static void sip_api_abstract_method(const char *classname, const char *method)
             classname, method);
 }
 
-
 /*
- * Report a deprecated class or method.
+ * Report a deprecated class or method with a given message.
  */
-int sip_api_deprecated(const char *classname, const char *method)
+int sip_api_deprecated(const char *classname, const char *method, const char *message)
 {
-    char buf[100];
+    const unsigned int bufsize = 100 + ( message ? strlen(message) : 0 );
+    char buf[bufsize];
 
     if (classname == NULL)
         PyOS_snprintf(buf, sizeof (buf), "%s() is deprecated", method);
@@ -6675,8 +6675,13 @@ int sip_api_deprecated(const char *classname, const char *method)
         PyOS_snprintf(buf, sizeof (buf), "%s constructor is deprecated",
                 classname);
     else
-        PyOS_snprintf(buf, sizeof (buf), "%s.%s() is deprecated", classname,
-                method);
+      PyOS_snprintf(buf, sizeof (buf), "%s.%s() is deprecated", classname, method );
+
+    if ( message )
+    {
+      int i = strlen(buf);
+      PyOS_snprintf(buf+i, sizeof (buf), " : %s", message);
+    }
 
     return PyErr_WarnEx(PyExc_DeprecationWarning, buf, 1);
 }

--- a/sipbuild/module/source/13/sip_core.c
+++ b/sipbuild/module/source/13/sip_core.c
@@ -545,7 +545,7 @@ static const sipAPIDef sip_api = {
     sip_api_instance_destroyed_ex,
     sip_api_is_py_method_12_8,
     sip_api_next_exception_handler,
-    NULL,
+    sip_api_deprecated_13_9,
     NULL,
     NULL,
     NULL,
@@ -6662,9 +6662,17 @@ static void sip_api_abstract_method(const char *classname, const char *method)
 }
 
 /*
+ * Report a deprecated class or method.
+ */
+int sip_api_deprecated(const char *classname, const char *method)
+{
+  return sip_api_deprecated_13_9( classname, method, NULL );
+}
+
+/*
  * Report a deprecated class or method with a given message.
  */
-int sip_api_deprecated(const char *classname, const char *method, const char *message)
+int sip_api_deprecated_13_9(const char *classname, const char *method, const char *message)
 {
     const unsigned int bufsize = 100 + ( message ? strlen(message) : 0 );
     char buf[bufsize];

--- a/sipbuild/module/source/13/sip_core.h
+++ b/sipbuild/module/source/13/sip_core.h
@@ -120,7 +120,7 @@ void *sip_api_force_convert_to_type_us(PyObject *pyObj, const sipTypeDef *td,
 int sip_api_convert_from_slice_object(PyObject *slice, Py_ssize_t length,
         Py_ssize_t *start, Py_ssize_t *stop, Py_ssize_t *step,
         Py_ssize_t *slicelength);
-int sip_api_deprecated(const char *classname, const char *method);
+  int sip_api_deprecated(const char *classname, const char *method, const char *message);
 const sipTypeDef *sip_api_type_scope(const sipTypeDef *td);
 
 

--- a/sipbuild/module/source/13/sip_core.h
+++ b/sipbuild/module/source/13/sip_core.h
@@ -120,7 +120,8 @@ void *sip_api_force_convert_to_type_us(PyObject *pyObj, const sipTypeDef *td,
 int sip_api_convert_from_slice_object(PyObject *slice, Py_ssize_t length,
         Py_ssize_t *start, Py_ssize_t *stop, Py_ssize_t *step,
         Py_ssize_t *slicelength);
-  int sip_api_deprecated(const char *classname, const char *method, const char *message);
+  int sip_api_deprecated(const char *classname, const char *method);
+  int sip_api_deprecated_13_9(const char *classname, const char *method, const char* message);
 const sipTypeDef *sip_api_type_scope(const sipTypeDef *td);
 
 


### PR DESCRIPTION
Supersedes #45 

- add an optionnal deprecated message to the /Deprecated/ annotation
- write down this message in a @deprecated decorator
- display the message when DeprecationWarning exception is raised in runtime code

It fixes #8 

