### PR TITLE
Timeline of SIP versions broken

### DIFF
--- a/sipbuild/generator/parser/parser_manager.py
+++ b/sipbuild/generator/parser/parser_manager.py
@@ -1289,7 +1289,7 @@ class ParserManager:
 
             return True
 
-        # See if there is a selected qualifier withing range.
+        # See if there is a selected qualifier within range.
         for qual in module.qualifiers:
             if qual.type is QualifierType.TIME and qual.timeline == timeline and qual.name in self.tags:
                 if lower_qual is not None and qual.order < lower_qual.order:

--- a/sipbuild/generator/parser/rules.py
+++ b/sipbuild/generator/parser/rules.py
@@ -3213,10 +3213,15 @@ def p_annotation(p):
     """annotation : NAME
         | NAME '=' annotation_value"""
 
+    p[0] = {}
+
+    if p.parser.pm.skipping:
+        return
+
     value = None if len(p) == 2 else p[3]
     value = p.parser.pm.validate_annotation(p, 1, value)
 
-    p[0] = {p[1]: value}
+    p[0][1] = value
 
 
 def p_annotation_value(p):

--- a/sipbuild/generator/specification.py
+++ b/sipbuild/generator/specification.py
@@ -1206,7 +1206,8 @@ class Qualifier:
     order: int = 0
 
     # The timeline number within the defining module if it is a TIME qualifier.
-    timeline: int = 0
+    # A negative value implies the SIP timeline.
+    timeline: int = -1
 
 
 @dataclass

--- a/sipbuild/module/abi_version.py
+++ b/sipbuild/module/abi_version.py
@@ -77,7 +77,9 @@ def resolve_abi_version(abi_version, module=True):
                         f"'{abi_version}' is not a valid ABI version")
     else:
         abi_major_version = sorted(os.listdir(_module_source_dir), key=int)[-1]
-        minimum_minor_version = 0
+        # v13.0 is deprecated so explicitly exclude it to avoid a later
+        # deprecation warning.
+        minimum_minor_version = 1 if abi_major_version == '13' else 0
 
     # Get the minor version of what we actually have.
     module_version = get_sip_module_version(abi_major_version)


### PR DESCRIPTION
The handling of the SIP versions timeline has been fixed.

Annotations are now only validated if they are known to be needed.

Resolves #47