### PR TITLE
fix deprecated update according to parent

### DIFF
--- a/sipbuild/generator/resolver/resolver.py
+++ b/sipbuild/generator/resolver/resolver.py
@@ -649,8 +649,8 @@ def _set_mro(spec, klass, error_log, seen=None):
     if klass.scope is not None:
         _set_mro(spec, klass.scope, error_log, seen=seen)
 
-        if klass.scope.deprecated:
-            klass.deprecated = True
+        if klass.scope.deprecated and not klass.deprecated:
+            klass.deprecated = klass.scope.deprecated
 
     if klass.iface_file.type is IfaceFileType.CLASS:
         # The first thing is itself.
@@ -687,8 +687,8 @@ def _set_mro(spec, klass, error_log, seen=None):
                 if klass.iface_file.module is spec.module:
                     superklass_mro.iface_file.needed = True
 
-                if superklass_mro.deprecated:
-                    klass.deprecated = True
+                if superklass_mro.deprecated and not klass.deprecated:
+                    klass.deprecated = superklass_mro.deprecated
 
                 # If the super-class is a QObject sub-class then this one is as
                 # well.
@@ -816,8 +816,9 @@ def _resolve_ctors(spec, klass, error_log):
                                     klass.iface_file.fq_cpp_name))
                     break
 
-        if klass.deprecated:
-            ctor.deprecated = True
+
+        if klass.deprecated and not ctor.deprecated :
+            ctor.deprecated = klass.deprecated   
 
 
 def _transform_casts(spec, klass, error_log):
@@ -873,8 +874,8 @@ def _add_default_copy_ctor(klass):
     ctor = Constructor(AccessSpecifier.PUBLIC, py_signature=signature,
             cpp_signature=signature)
 
-    if klass.deprecated:
-        ctor.deprecated = True
+    if klass.deprecated and not ctor.deprecated :
+        ctor.deprecated = klass.deprecated
 
     if not klass.is_abstract:
         klass.can_create = True
@@ -919,8 +920,9 @@ def _resolve_scope_overloads(spec, overloads, error_log, final_checks,
                     break
 
         if isinstance(scope, WrappedClass):
-            if scope.deprecated:
-                overload.deprecated = True
+
+            if scope.deprecated and not overload.deprecated :
+                overload.deprecated = scope.deprecated
 
             if overload.is_abstract:
                 scope.is_abstract = True


### PR DESCRIPTION
revert part of #50 

with #50 True is displayed instead of the deprecation message

```shell
(.venv) ➜  test git:(master) ✗ python test.py
/home/julien/myconf/sip-examples/deprecated/test/test.py:9: DeprecationWarning: Test constructor is deprecated: True
  a=Test()
/home/julien/myconf/sip-examples/deprecated/test/test.py:10: DeprecationWarning: Test.printTestDeprecated() is deprecated: True
  a.printTestDeprecated() # this is a comment
```

The PR proposes to : 
- not update current item deprecated with parent if another more specific message exist on the current item
- Update current item with parent message and not True when there is no overloaded message defined on current item
